### PR TITLE
Theme name variable should be lower case

### DIFF
--- a/arc-theme-upgrade
+++ b/arc-theme-upgrade
@@ -3,7 +3,7 @@
 # Script to upgrade/install the arc-theme
 
 #URL
-theme_name=Arc-theme
+theme_name=arc-theme
 
 # Theme name
 download_url=https://github.com/horst3180/$theme_name/archive/master.tar.gz


### PR DESCRIPTION
This variable is used in line 88 which requires a lower-case arc-theme-master string.