### PR TITLE
Update gtk.css

### DIFF
--- a/common/gtk-3.0/3.18/gtk.css
+++ b/common/gtk-3.0/3.18/gtk.css
@@ -21,8 +21,10 @@
   -GtkDialog-button-spacing: 4;
   -GtkDialog-action-area-border: 0;
   -GtkStatusbar-shadow-type: none;
-  outline-color: rgba(92, 97, 108, 0.3);
-  outline-style: dashed;
+/*  outline-color: rgba(92, 97, 108, 0.3);*/
+/*  outline-style: dashed;*/
+  outline-color: transparent;
+  outline-style: none;
   outline-offset: -3px;
   outline-width: 1px;
   outline-radius: 2px; }


### PR DESCRIPTION
Fix for Gtk3 themes in Mate.

GTK3 apps showed dashed borders around every elements on the interface. This bugfix + reloading theme (logout & login) fixed the issue.