### PR TITLE
Add theming for Unity Greeter

### DIFF
--- a/common/gtk-3.0/3.14/gtk-dark.css
+++ b/common/gtk-3.0/3.14/gtk-dark.css
@@ -3279,7 +3279,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.14/gtk-dark.css
+++ b/common/gtk-3.0/3.14/gtk-dark.css
@@ -3268,9 +3268,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3281,7 +3283,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.14/gtk-dark.css
+++ b/common/gtk-3.0/3.14/gtk-dark.css
@@ -3257,19 +3257,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: #4a4f61;
+  background-color: rgba(64, 71, 86, 0.97);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3278,34 +3286,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.14/gtk-dark.css
+++ b/common/gtk-3.0/3.14/gtk-dark.css
@@ -3248,6 +3248,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: #4a4f61;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.14/gtk-darker.css
+++ b/common/gtk-3.0/3.14/gtk-darker.css
@@ -3260,19 +3260,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: rgba(64, 71, 86, 0.97);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3281,34 +3289,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.14/gtk-darker.css
+++ b/common/gtk-3.0/3.14/gtk-darker.css
@@ -3271,9 +3271,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3284,7 +3286,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.14/gtk-darker.css
+++ b/common/gtk-3.0/3.14/gtk-darker.css
@@ -3251,6 +3251,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.14/gtk-darker.css
+++ b/common/gtk-3.0/3.14/gtk-darker.css
@@ -3282,7 +3282,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.14/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.14/gtk-solid-dark.css
@@ -3279,7 +3279,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.14/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.14/gtk-solid-dark.css
@@ -3268,9 +3268,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3281,7 +3283,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.14/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.14/gtk-solid-dark.css
@@ -3248,6 +3248,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: #4a4f61;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.14/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.14/gtk-solid-dark.css
@@ -3257,19 +3257,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: #4a4f61;
+  background-color: #404756;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3278,34 +3286,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.14/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.14/gtk-solid-darker.css
@@ -3260,19 +3260,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: #404756;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3281,34 +3289,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.14/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.14/gtk-solid-darker.css
@@ -3271,9 +3271,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3284,7 +3286,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.14/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.14/gtk-solid-darker.css
@@ -3251,6 +3251,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.14/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.14/gtk-solid-darker.css
@@ -3282,7 +3282,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.14/gtk-solid.css
+++ b/common/gtk-3.0/3.14/gtk-solid.css
@@ -3260,19 +3260,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: #fdfdfe;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3281,34 +3289,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.14/gtk-solid.css
+++ b/common/gtk-3.0/3.14/gtk-solid.css
@@ -3271,9 +3271,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3284,7 +3286,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.14/gtk-solid.css
+++ b/common/gtk-3.0/3.14/gtk-solid.css
@@ -3251,6 +3251,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.14/gtk-solid.css
+++ b/common/gtk-3.0/3.14/gtk-solid.css
@@ -3282,7 +3282,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.14/gtk.css
+++ b/common/gtk-3.0/3.14/gtk.css
@@ -3271,9 +3271,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3284,7 +3286,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.14/gtk.css
+++ b/common/gtk-3.0/3.14/gtk.css
@@ -3251,6 +3251,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.14/gtk.css
+++ b/common/gtk-3.0/3.14/gtk.css
@@ -3282,7 +3282,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.14/gtk.css
+++ b/common/gtk-3.0/3.14/gtk.css
@@ -3260,19 +3260,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: rgba(253, 253, 254, 0.95);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3281,34 +3289,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.14/sass/_unity.scss
+++ b/common/gtk-3.0/3.14/sass/_unity.scss
@@ -69,95 +69,81 @@ UnityPanelWidget,
 }
 
 .lightdm-combo .menu {
-  background-color: lighten($bg_color, 8);
+  background-color: lighten($header_bg, 8);
   border-radius: 0px;
   padding: 0px;
   color: white;
 }
 
-.lightdm {
-  &.menu .menuitem {
-    *, &.check:active, &.radio:active {
-      color: white;
-    }
-  }
-  &.menubar {
-    background-image: none;
-    background-color: transparentize(black, 0.5);
-  }
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
+  color: white;
 }
 
-.lightdm-combo {
-  &.combobox-entry .button, .cell, .button, .entry {
-    background-image: none;
-    background-color: transparentize(black, 0.3);
-    border-color: transparentize(white, 0.6);
-    border-radius: 5px;
-    padding: 7px;
-    color: white;
-    text-shadow: none;
-  }
+.lightdm.menubar {
+  color: white;
+  background-image: none;
+  background-color: transparentize(black, 0.5);
 }
 
-.lightdm {
-  &.button, &.entry {
-    background-image: none;
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
+  background-image: none;
+  background-color: transparentize(black, 0.3);
+  border-color: transparentize(white, 0.6);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none;
+}
+
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
+  background-image: none;
+  border-image: none;
+}
+
+.lightdm.button:focused,
+.lightdm.entry:focused {
+  border-color: transparentize(white, 0.9);
+  border-width: 1px;
+  border-style: solid;
+  color: white;
+}
+
+.lightdm.entry:selected {
+  background-color: transparentize(white, 0.2);
+}
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear;
+}
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0;
+}
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0;
+
+  &.selected {
     background-color: transparentize(black, 0.3);
-    border-color: transparentize(white, 0.6);
-    border-radius: 5px;
-    padding: 7px;
-    color: white;
-    text-shadow: none;
-  }
-  &.button, &.entry {
-    background-image: none;
-    border-image: none;
-    &:hover {
-      background-image: none;
-      border-image: none;
-    }
-    &:active {
-      background-image: none;
-      border-image: none;
-      &:focused {
-        background-image: none;
-        border-image: none;
-      }
-    }
-  }
-  &.button:focused {
-    border-color: transparentize(white, 0.9);
     border-width: 1px;
-    border-style: solid;
-    color: white;
-  }
-  &.entry {
-    &:focused {
-      border-color: transparentize(white, 0.9);
-      border-width: 1px;
-      border-style: solid;
-      color: white;
-    }
-    &:selected {
-      background-color: transparentize(white, 0.2);
-    }
-    &:active {
-      -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
-      animation: dashentry_spinner 1s infinite linear;
-    }
-  }
-  &.option-button {
-    padding: 2px;
-    background: none;
-    border: 0;
-  }
-  &.toggle-button {
-    background: none;
-    border-width: 0;
-    &.selected {
-      background-color: transparentize(black, 0.3);
-      border-width: 1px;
-    }
   }
 }
 

--- a/common/gtk-3.0/3.14/sass/_unity.scss
+++ b/common/gtk-3.0/3.14/sass/_unity.scss
@@ -61,15 +61,15 @@ UnityPanelWidget,
 // Unity Greeter
 .lightdm.menu {
   background-image: none;
-  background-color: alpha(black, 0.6);
-  border-color: alpha(white, 0.2);
+  background-color: transparentize(black, 0.6);
+  border-color: transparentize(white, 0.2);
   border-radius: 4px;
   padding: 1px;
   color: white;
 }
 
 .lightdm-combo .menu {
-  background-color: shade($bg_color, 1.08);
+  background-color: lighten($bg_color, 8);
   border-radius: 0px;
   padding: 0px;
   color: white;
@@ -83,15 +83,15 @@ UnityPanelWidget,
   }
   &.menubar {
     background-image: none;
-    background-color: alpha(black, 0.5);
+    background-color: transparentize(black, 0.5);
   }
 }
 
 .lightdm-combo {
   &.combobox-entry .button, .cell, .button, .entry {
     background-image: none;
-    background-color: alpha(black, 0.3);
-    border-color: alpha(white, 0.6);
+    background-color: transparentize(black, 0.3);
+    border-color: transparentize(white, 0.6);
     border-radius: 5px;
     padding: 7px;
     color: white;
@@ -102,8 +102,8 @@ UnityPanelWidget,
 .lightdm {
   &.button, &.entry {
     background-image: none;
-    background-color: alpha(black, 0.3);
-    border-color: alpha(white, 0.6);
+    background-color: transparentize(black, 0.3);
+    border-color: transparentize(white, 0.6);
     border-radius: 5px;
     padding: 7px;
     color: white;
@@ -126,20 +126,20 @@ UnityPanelWidget,
     }
   }
   &.button:focused {
-    border-color: alpha(white, 0.9);
+    border-color: transparentize(white, 0.9);
     border-width: 1px;
     border-style: solid;
     color: white;
   }
   &.entry {
     &:focused {
-      border-color: alpha(white, 0.9);
+      border-color: transparentize(white, 0.9);
       border-width: 1px;
       border-style: solid;
       color: white;
     }
     &:selected {
-      background-color: alpha(white, 0.2);
+      background-color: transparentize(white, 0.2);
     }
     &:active {
       -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
@@ -155,7 +155,7 @@ UnityPanelWidget,
     background: none;
     border-width: 0;
     &.selected {
-      background-color: alpha(black, 0.3);
+      background-color: transparentize(black, 0.3);
       border-width: 1px;
     }
   }

--- a/common/gtk-3.0/3.14/sass/_unity.scss
+++ b/common/gtk-3.0/3.14/sass/_unity.scss
@@ -57,3 +57,112 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, $selected_bg_color);
   border-bottom: none;
 }
+
+// Unity Greeter
+.lightdm.menu {
+  background-image: none;
+  background-color: alpha(black, 0.6);
+  border-color: alpha(white, 0.2);
+  border-radius: 4px;
+  padding: 1px;
+  color: white;
+}
+
+.lightdm-combo .menu {
+  background-color: shade($bg_color, 1.08);
+  border-radius: 0px;
+  padding: 0px;
+  color: white;
+}
+
+.lightdm {
+  &.menu .menuitem {
+    *, &.check:active, &.radio:active {
+      color: white;
+    }
+  }
+  &.menubar {
+    background-image: none;
+    background-color: alpha(black, 0.5);
+  }
+}
+
+.lightdm-combo {
+  &.combobox-entry .button, .cell, .button, .entry {
+    background-image: none;
+    background-color: alpha(black, 0.3);
+    border-color: alpha(white, 0.6);
+    border-radius: 5px;
+    padding: 7px;
+    color: white;
+    text-shadow: none;
+  }
+}
+
+.lightdm {
+  &.button, &.entry {
+    background-image: none;
+    background-color: alpha(black, 0.3);
+    border-color: alpha(white, 0.6);
+    border-radius: 5px;
+    padding: 7px;
+    color: white;
+    text-shadow: none;
+  }
+  &.button, &.entry {
+    background-image: none;
+    border-image: none;
+    &:hover {
+      background-image: none;
+      border-image: none;
+    }
+    &:active {
+      background-image: none;
+      border-image: none;
+      &:focused {
+        background-image: none;
+        border-image: none;
+      }
+    }
+  }
+  &.button:focused {
+    border-color: alpha(white, 0.9);
+    border-width: 1px;
+    border-style: solid;
+    color: white;
+  }
+  &.entry {
+    &:focused {
+      border-color: alpha(white, 0.9);
+      border-width: 1px;
+      border-style: solid;
+      color: white;
+    }
+    &:selected {
+      background-color: alpha(white, 0.2);
+    }
+    &:active {
+      -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+      animation: dashentry_spinner 1s infinite linear;
+    }
+  }
+  &.option-button {
+    padding: 2px;
+    background: none;
+    border: 0;
+  }
+  &.toggle-button {
+    background: none;
+    border-width: 0;
+    &.selected {
+      background-color: alpha(black, 0.3);
+      border-width: 1px;
+    }
+  }
+}
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn);
+  }
+}

--- a/common/gtk-3.0/3.14/sass/_unity.scss
+++ b/common/gtk-3.0/3.14/sass/_unity.scss
@@ -94,7 +94,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: transparentize(black, 0.3);
+  background-color: transparentize(black, 0.7);
   border-color: transparentize(white, 0.6);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.14/sass/_unity.scss
+++ b/common/gtk-3.0/3.14/sass/_unity.scss
@@ -82,9 +82,13 @@ UnityPanelWidget,
 }
 
 .lightdm.menubar {
-  color: white;
+  color: transparentize(white, 0.2);
   background-image: none;
   background-color: transparentize(black, 0.5);
+
+  & > .menuitem {
+    padding: 2px 6px;
+  }
 }
 
 .lightdm-combo.combobox-entry .button,
@@ -96,7 +100,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: transparentize(black, 0.7);
   border-color: transparentize(white, 0.6);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none;

--- a/common/gtk-3.0/3.16/gtk-dark.css
+++ b/common/gtk-3.0/3.16/gtk-dark.css
@@ -3155,7 +3155,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.16/gtk-dark.css
+++ b/common/gtk-3.0/3.16/gtk-dark.css
@@ -3133,19 +3133,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: #4a4f61;
+  background-color: rgba(64, 71, 86, 0.97);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3154,34 +3162,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.16/gtk-dark.css
+++ b/common/gtk-3.0/3.16/gtk-dark.css
@@ -3144,9 +3144,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3157,7 +3159,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.16/gtk-dark.css
+++ b/common/gtk-3.0/3.16/gtk-dark.css
@@ -3124,6 +3124,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: #4a4f61;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.16/gtk-darker.css
+++ b/common/gtk-3.0/3.16/gtk-darker.css
@@ -3158,7 +3158,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.16/gtk-darker.css
+++ b/common/gtk-3.0/3.16/gtk-darker.css
@@ -3147,9 +3147,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3160,7 +3162,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.16/gtk-darker.css
+++ b/common/gtk-3.0/3.16/gtk-darker.css
@@ -3136,19 +3136,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: rgba(64, 71, 86, 0.97);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3157,34 +3165,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.16/gtk-darker.css
+++ b/common/gtk-3.0/3.16/gtk-darker.css
@@ -3127,6 +3127,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.16/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.16/gtk-solid-dark.css
@@ -3155,7 +3155,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.16/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.16/gtk-solid-dark.css
@@ -3133,19 +3133,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: #4a4f61;
+  background-color: #404756;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3154,34 +3162,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.16/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.16/gtk-solid-dark.css
@@ -3144,9 +3144,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3157,7 +3159,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.16/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.16/gtk-solid-dark.css
@@ -3124,6 +3124,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: #4a4f61;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.16/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.16/gtk-solid-darker.css
@@ -3158,7 +3158,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.16/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.16/gtk-solid-darker.css
@@ -3147,9 +3147,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3160,7 +3162,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.16/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.16/gtk-solid-darker.css
@@ -3127,6 +3127,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.16/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.16/gtk-solid-darker.css
@@ -3136,19 +3136,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: #404756;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3157,34 +3165,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.16/gtk-solid.css
+++ b/common/gtk-3.0/3.16/gtk-solid.css
@@ -3158,7 +3158,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.16/gtk-solid.css
+++ b/common/gtk-3.0/3.16/gtk-solid.css
@@ -3147,9 +3147,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3160,7 +3162,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.16/gtk-solid.css
+++ b/common/gtk-3.0/3.16/gtk-solid.css
@@ -3136,19 +3136,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: #fdfdfe;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3157,34 +3165,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.16/gtk-solid.css
+++ b/common/gtk-3.0/3.16/gtk-solid.css
@@ -3127,6 +3127,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.16/gtk.css
+++ b/common/gtk-3.0/3.16/gtk.css
@@ -3136,19 +3136,27 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: rgba(253, 253, 254, 0.95);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3157,34 +3165,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.16/gtk.css
+++ b/common/gtk-3.0/3.16/gtk.css
@@ -3158,7 +3158,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.16/gtk.css
+++ b/common/gtk-3.0/3.16/gtk.css
@@ -3147,9 +3147,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3160,7 +3162,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.16/gtk.css
+++ b/common/gtk-3.0/3.16/gtk.css
@@ -3127,6 +3127,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.16/sass/_unity.scss
+++ b/common/gtk-3.0/3.16/sass/_unity.scss
@@ -69,95 +69,81 @@ UnityPanelWidget,
 }
 
 .lightdm-combo .menu {
-  background-color: lighten($bg_color, 8);
+  background-color: lighten($header_bg, 8);
   border-radius: 0px;
   padding: 0px;
   color: white;
 }
 
-.lightdm {
-  &.menu .menuitem {
-    *, &.check:active, &.radio:active {
-      color: white;
-    }
-  }
-  &.menubar {
-    background-image: none;
-    background-color: transparentize(black, 0.5);
-  }
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
+  color: white;
 }
 
-.lightdm-combo {
-  &.combobox-entry .button, .cell, .button, .entry {
-    background-image: none;
-    background-color: transparentize(black, 0.3);
-    border-color: transparentize(white, 0.6);
-    border-radius: 5px;
-    padding: 7px;
-    color: white;
-    text-shadow: none;
-  }
+.lightdm.menubar {
+  color: white;
+  background-image: none;
+  background-color: transparentize(black, 0.5);
 }
 
-.lightdm {
-  &.button, &.entry {
-    background-image: none;
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
+  background-image: none;
+  background-color: transparentize(black, 0.3);
+  border-color: transparentize(white, 0.6);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none;
+}
+
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
+  background-image: none;
+  border-image: none;
+}
+
+.lightdm.button:focused,
+.lightdm.entry:focused {
+  border-color: transparentize(white, 0.9);
+  border-width: 1px;
+  border-style: solid;
+  color: white;
+}
+
+.lightdm.entry:selected {
+  background-color: transparentize(white, 0.2);
+}
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear;
+}
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0;
+}
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0;
+
+  &.selected {
     background-color: transparentize(black, 0.3);
-    border-color: transparentize(white, 0.6);
-    border-radius: 5px;
-    padding: 7px;
-    color: white;
-    text-shadow: none;
-  }
-  &.button, &.entry {
-    background-image: none;
-    border-image: none;
-    &:hover {
-      background-image: none;
-      border-image: none;
-    }
-    &:active {
-      background-image: none;
-      border-image: none;
-      &:focused {
-        background-image: none;
-        border-image: none;
-      }
-    }
-  }
-  &.button:focused {
-    border-color: transparentize(white, 0.9);
     border-width: 1px;
-    border-style: solid;
-    color: white;
-  }
-  &.entry {
-    &:focused {
-      border-color: transparentize(white, 0.9);
-      border-width: 1px;
-      border-style: solid;
-      color: white;
-    }
-    &:selected {
-      background-color: transparentize(white, 0.2);
-    }
-    &:active {
-      -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
-      animation: dashentry_spinner 1s infinite linear;
-    }
-  }
-  &.option-button {
-    padding: 2px;
-    background: none;
-    border: 0;
-  }
-  &.toggle-button {
-    background: none;
-    border-width: 0;
-    &.selected {
-      background-color: transparentize(black, 0.3);
-      border-width: 1px;
-    }
   }
 }
 

--- a/common/gtk-3.0/3.16/sass/_unity.scss
+++ b/common/gtk-3.0/3.16/sass/_unity.scss
@@ -61,15 +61,15 @@ UnityPanelWidget,
 // Unity Greeter
 .lightdm.menu {
   background-image: none;
-  background-color: alpha(black, 0.6);
-  border-color: alpha(white, 0.2);
+  background-color: transparentize(black, 0.6);
+  border-color: transparentize(white, 0.2);
   border-radius: 4px;
   padding: 1px;
   color: white;
 }
 
 .lightdm-combo .menu {
-  background-color: shade($bg_color, 1.08);
+  background-color: lighten($bg_color, 8);
   border-radius: 0px;
   padding: 0px;
   color: white;
@@ -83,15 +83,15 @@ UnityPanelWidget,
   }
   &.menubar {
     background-image: none;
-    background-color: alpha(black, 0.5);
+    background-color: transparentize(black, 0.5);
   }
 }
 
 .lightdm-combo {
   &.combobox-entry .button, .cell, .button, .entry {
     background-image: none;
-    background-color: alpha(black, 0.3);
-    border-color: alpha(white, 0.6);
+    background-color: transparentize(black, 0.3);
+    border-color: transparentize(white, 0.6);
     border-radius: 5px;
     padding: 7px;
     color: white;
@@ -102,8 +102,8 @@ UnityPanelWidget,
 .lightdm {
   &.button, &.entry {
     background-image: none;
-    background-color: alpha(black, 0.3);
-    border-color: alpha(white, 0.6);
+    background-color: transparentize(black, 0.3);
+    border-color: transparentize(white, 0.6);
     border-radius: 5px;
     padding: 7px;
     color: white;
@@ -126,20 +126,20 @@ UnityPanelWidget,
     }
   }
   &.button:focused {
-    border-color: alpha(white, 0.9);
+    border-color: transparentize(white, 0.9);
     border-width: 1px;
     border-style: solid;
     color: white;
   }
   &.entry {
     &:focused {
-      border-color: alpha(white, 0.9);
+      border-color: transparentize(white, 0.9);
       border-width: 1px;
       border-style: solid;
       color: white;
     }
     &:selected {
-      background-color: alpha(white, 0.2);
+      background-color: transparentize(white, 0.2);
     }
     &:active {
       -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
@@ -155,7 +155,7 @@ UnityPanelWidget,
     background: none;
     border-width: 0;
     &.selected {
-      background-color: alpha(black, 0.3);
+      background-color: transparentize(black, 0.3);
       border-width: 1px;
     }
   }

--- a/common/gtk-3.0/3.16/sass/_unity.scss
+++ b/common/gtk-3.0/3.16/sass/_unity.scss
@@ -57,3 +57,112 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, $selected_bg_color);
   border-bottom: none;
 }
+
+// Unity Greeter
+.lightdm.menu {
+  background-image: none;
+  background-color: alpha(black, 0.6);
+  border-color: alpha(white, 0.2);
+  border-radius: 4px;
+  padding: 1px;
+  color: white;
+}
+
+.lightdm-combo .menu {
+  background-color: shade($bg_color, 1.08);
+  border-radius: 0px;
+  padding: 0px;
+  color: white;
+}
+
+.lightdm {
+  &.menu .menuitem {
+    *, &.check:active, &.radio:active {
+      color: white;
+    }
+  }
+  &.menubar {
+    background-image: none;
+    background-color: alpha(black, 0.5);
+  }
+}
+
+.lightdm-combo {
+  &.combobox-entry .button, .cell, .button, .entry {
+    background-image: none;
+    background-color: alpha(black, 0.3);
+    border-color: alpha(white, 0.6);
+    border-radius: 5px;
+    padding: 7px;
+    color: white;
+    text-shadow: none;
+  }
+}
+
+.lightdm {
+  &.button, &.entry {
+    background-image: none;
+    background-color: alpha(black, 0.3);
+    border-color: alpha(white, 0.6);
+    border-radius: 5px;
+    padding: 7px;
+    color: white;
+    text-shadow: none;
+  }
+  &.button, &.entry {
+    background-image: none;
+    border-image: none;
+    &:hover {
+      background-image: none;
+      border-image: none;
+    }
+    &:active {
+      background-image: none;
+      border-image: none;
+      &:focused {
+        background-image: none;
+        border-image: none;
+      }
+    }
+  }
+  &.button:focused {
+    border-color: alpha(white, 0.9);
+    border-width: 1px;
+    border-style: solid;
+    color: white;
+  }
+  &.entry {
+    &:focused {
+      border-color: alpha(white, 0.9);
+      border-width: 1px;
+      border-style: solid;
+      color: white;
+    }
+    &:selected {
+      background-color: alpha(white, 0.2);
+    }
+    &:active {
+      -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+      animation: dashentry_spinner 1s infinite linear;
+    }
+  }
+  &.option-button {
+    padding: 2px;
+    background: none;
+    border: 0;
+  }
+  &.toggle-button {
+    background: none;
+    border-width: 0;
+    &.selected {
+      background-color: alpha(black, 0.3);
+      border-width: 1px;
+    }
+  }
+}
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn);
+  }
+}

--- a/common/gtk-3.0/3.16/sass/_unity.scss
+++ b/common/gtk-3.0/3.16/sass/_unity.scss
@@ -94,7 +94,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: transparentize(black, 0.3);
+  background-color: transparentize(black, 0.7);
   border-color: transparentize(white, 0.6);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.16/sass/_unity.scss
+++ b/common/gtk-3.0/3.16/sass/_unity.scss
@@ -82,9 +82,13 @@ UnityPanelWidget,
 }
 
 .lightdm.menubar {
-  color: white;
+  color: transparentize(white, 0.2);
   background-image: none;
   background-color: transparentize(black, 0.5);
+
+  & > .menuitem {
+    padding: 2px 6px;
+  }
 }
 
 .lightdm-combo.combobox-entry .button,
@@ -96,7 +100,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: transparentize(black, 0.7);
   border-color: transparentize(white, 0.6);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none;

--- a/common/gtk-3.0/3.18/gtk-dark.css
+++ b/common/gtk-3.0/3.18/gtk-dark.css
@@ -3298,9 +3298,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3311,7 +3313,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.18/gtk-dark.css
+++ b/common/gtk-3.0/3.18/gtk-dark.css
@@ -3278,6 +3278,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: #4a4f61;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.18/gtk-dark.css
+++ b/common/gtk-3.0/3.18/gtk-dark.css
@@ -3298,6 +3298,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3308,7 +3309,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.18/gtk-dark.css
+++ b/common/gtk-3.0/3.18/gtk-dark.css
@@ -3287,19 +3287,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: #4a4f61;
+  background-color: rgba(64, 71, 86, 0.97);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3308,34 +3315,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.18/gtk-darker.css
+++ b/common/gtk-3.0/3.18/gtk-darker.css
@@ -3301,9 +3301,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3314,7 +3316,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.18/gtk-darker.css
+++ b/common/gtk-3.0/3.18/gtk-darker.css
@@ -3290,19 +3290,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: rgba(64, 71, 86, 0.97);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3311,34 +3318,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.18/gtk-darker.css
+++ b/common/gtk-3.0/3.18/gtk-darker.css
@@ -3281,6 +3281,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.18/gtk-darker.css
+++ b/common/gtk-3.0/3.18/gtk-darker.css
@@ -3301,6 +3301,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3311,7 +3312,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.18/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.18/gtk-solid-dark.css
@@ -3298,9 +3298,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3311,7 +3313,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.18/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.18/gtk-solid-dark.css
@@ -3278,6 +3278,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: #4a4f61;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.18/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.18/gtk-solid-dark.css
@@ -3298,6 +3298,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3308,7 +3309,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.18/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.18/gtk-solid-dark.css
@@ -3287,19 +3287,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: #4a4f61;
+  background-color: #404756;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3308,34 +3315,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.18/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.18/gtk-solid-darker.css
@@ -3301,9 +3301,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3314,7 +3316,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.18/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.18/gtk-solid-darker.css
@@ -3281,6 +3281,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.18/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.18/gtk-solid-darker.css
@@ -3301,6 +3301,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3311,7 +3312,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.18/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.18/gtk-solid-darker.css
@@ -3290,19 +3290,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: #404756;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3311,34 +3318,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.18/gtk-solid.css
+++ b/common/gtk-3.0/3.18/gtk-solid.css
@@ -3294,19 +3294,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: #fdfdfe;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3315,34 +3322,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.18/gtk-solid.css
+++ b/common/gtk-3.0/3.18/gtk-solid.css
@@ -3305,6 +3305,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3315,7 +3316,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.18/gtk-solid.css
+++ b/common/gtk-3.0/3.18/gtk-solid.css
@@ -3305,9 +3305,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3318,7 +3320,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.18/gtk-solid.css
+++ b/common/gtk-3.0/3.18/gtk-solid.css
@@ -3285,6 +3285,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.18/gtk.css
+++ b/common/gtk-3.0/3.18/gtk.css
@@ -3305,6 +3305,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3315,7 +3316,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.18/gtk.css
+++ b/common/gtk-3.0/3.18/gtk.css
@@ -3305,9 +3305,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3318,7 +3320,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.18/gtk.css
+++ b/common/gtk-3.0/3.18/gtk.css
@@ -3294,19 +3294,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: rgba(253, 253, 254, 0.95);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3315,34 +3322,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.18/gtk.css
+++ b/common/gtk-3.0/3.18/gtk.css
@@ -3285,6 +3285,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.18/sass/_unity.scss
+++ b/common/gtk-3.0/3.18/sass/_unity.scss
@@ -61,15 +61,15 @@ UnityPanelWidget,
 // Unity Greeter
 .lightdm.menu {
   background-image: none;
-  background-color: alpha(black, 0.6);
-  border-color: alpha(white, 0.2);
+  background-color: transparentize(black, 0.6);
+  border-color: transparentize(white, 0.2);
   border-radius: 4px;
   padding: 1px;
   color: white;
 }
 
 .lightdm-combo .menu {
-  background-color: shade($bg_color, 1.08);
+  background-color: lighten($bg_color, 8);
   border-radius: 0px;
   padding: 0px;
   color: white;
@@ -83,15 +83,15 @@ UnityPanelWidget,
   }
   &.menubar {
     background-image: none;
-    background-color: alpha(black, 0.5);
+    background-color: transparentize(black, 0.5);
   }
 }
 
 .lightdm-combo {
   &.combobox-entry .button, .cell, .button, .entry {
     background-image: none;
-    background-color: alpha(black, 0.3);
-    border-color: alpha(white, 0.6);
+    background-color: transparentize(black, 0.3);
+    border-color: transparentize(white, 0.6);
     border-radius: 5px;
     padding: 7px;
     color: white;
@@ -102,8 +102,8 @@ UnityPanelWidget,
 .lightdm {
   &.button, &.entry {
     background-image: none;
-    background-color: alpha(black, 0.3);
-    border-color: alpha(white, 0.6);
+    background-color: transparentize(black, 0.3);
+    border-color: transparentize(white, 0.6);
     border-radius: 5px;
     padding: 7px;
     color: white;
@@ -126,20 +126,20 @@ UnityPanelWidget,
     }
   }
   &.button:focused {
-    border-color: alpha(white, 0.9);
+    border-color: transparentize(white, 0.9);
     border-width: 1px;
     border-style: solid;
     color: white;
   }
   &.entry {
     &:focused {
-      border-color: alpha(white, 0.9);
+      border-color: transparentize(white, 0.9);
       border-width: 1px;
       border-style: solid;
       color: white;
     }
     &:selected {
-      background-color: alpha(white, 0.2);
+      background-color: transparentize(white, 0.2);
     }
     &:active {
       -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
@@ -155,7 +155,7 @@ UnityPanelWidget,
     background: none;
     border-width: 0;
     &.selected {
-      background-color: alpha(black, 0.3);
+      background-color: transparentize(black, 0.3);
       border-width: 1px;
     }
   }

--- a/common/gtk-3.0/3.18/sass/_unity.scss
+++ b/common/gtk-3.0/3.18/sass/_unity.scss
@@ -57,3 +57,112 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, $selected_bg_color);
   border-bottom: none;
 }
+
+// Unity Greeter
+.lightdm.menu {
+  background-image: none;
+  background-color: alpha(black, 0.6);
+  border-color: alpha(white, 0.2);
+  border-radius: 4px;
+  padding: 1px;
+  color: white;
+}
+
+.lightdm-combo .menu {
+  background-color: shade($bg_color, 1.08);
+  border-radius: 0px;
+  padding: 0px;
+  color: white;
+}
+
+.lightdm {
+  &.menu .menuitem {
+    *, &.check:active, &.radio:active {
+      color: white;
+    }
+  }
+  &.menubar {
+    background-image: none;
+    background-color: alpha(black, 0.5);
+  }
+}
+
+.lightdm-combo {
+  &.combobox-entry .button, .cell, .button, .entry {
+    background-image: none;
+    background-color: alpha(black, 0.3);
+    border-color: alpha(white, 0.6);
+    border-radius: 5px;
+    padding: 7px;
+    color: white;
+    text-shadow: none;
+  }
+}
+
+.lightdm {
+  &.button, &.entry {
+    background-image: none;
+    background-color: alpha(black, 0.3);
+    border-color: alpha(white, 0.6);
+    border-radius: 5px;
+    padding: 7px;
+    color: white;
+    text-shadow: none;
+  }
+  &.button, &.entry {
+    background-image: none;
+    border-image: none;
+    &:hover {
+      background-image: none;
+      border-image: none;
+    }
+    &:active {
+      background-image: none;
+      border-image: none;
+      &:focused {
+        background-image: none;
+        border-image: none;
+      }
+    }
+  }
+  &.button:focused {
+    border-color: alpha(white, 0.9);
+    border-width: 1px;
+    border-style: solid;
+    color: white;
+  }
+  &.entry {
+    &:focused {
+      border-color: alpha(white, 0.9);
+      border-width: 1px;
+      border-style: solid;
+      color: white;
+    }
+    &:selected {
+      background-color: alpha(white, 0.2);
+    }
+    &:active {
+      -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+      animation: dashentry_spinner 1s infinite linear;
+    }
+  }
+  &.option-button {
+    padding: 2px;
+    background: none;
+    border: 0;
+  }
+  &.toggle-button {
+    background: none;
+    border-width: 0;
+    &.selected {
+      background-color: alpha(black, 0.3);
+      border-width: 1px;
+    }
+  }
+}
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn);
+  }
+}

--- a/common/gtk-3.0/3.18/sass/_unity.scss
+++ b/common/gtk-3.0/3.18/sass/_unity.scss
@@ -82,6 +82,7 @@ UnityPanelWidget,
 }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: transparentize(black, 0.5);
 }
@@ -93,7 +94,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: transparentize(black, 0.3);
+  background-color: transparentize(black, 0.7);
   border-color: transparentize(white, 0.6);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.18/sass/_unity.scss
+++ b/common/gtk-3.0/3.18/sass/_unity.scss
@@ -69,95 +69,80 @@ UnityPanelWidget,
 }
 
 .lightdm-combo .menu {
-  background-color: lighten($bg_color, 8);
+  background-color: lighten($header_bg, 8);
   border-radius: 0px;
   padding: 0px;
   color: white;
 }
 
-.lightdm {
-  &.menu .menuitem {
-    *, &.check:active, &.radio:active {
-      color: white;
-    }
-  }
-  &.menubar {
-    background-image: none;
-    background-color: transparentize(black, 0.5);
-  }
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
+  color: white;
 }
 
-.lightdm-combo {
-  &.combobox-entry .button, .cell, .button, .entry {
-    background-image: none;
-    background-color: transparentize(black, 0.3);
-    border-color: transparentize(white, 0.6);
-    border-radius: 5px;
-    padding: 7px;
-    color: white;
-    text-shadow: none;
-  }
+.lightdm.menubar {
+  background-image: none;
+  background-color: transparentize(black, 0.5);
 }
 
-.lightdm {
-  &.button, &.entry {
-    background-image: none;
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
+  background-image: none;
+  background-color: transparentize(black, 0.3);
+  border-color: transparentize(white, 0.6);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none;
+}
+
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
+  background-image: none;
+  border-image: none;
+}
+
+.lightdm.button:focused,
+.lightdm.entry:focused {
+  border-color: transparentize(white, 0.9);
+  border-width: 1px;
+  border-style: solid;
+  color: white;
+}
+
+.lightdm.entry:selected {
+  background-color: transparentize(white, 0.2);
+}
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear;
+}
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0;
+}
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0;
+
+  &.selected {
     background-color: transparentize(black, 0.3);
-    border-color: transparentize(white, 0.6);
-    border-radius: 5px;
-    padding: 7px;
-    color: white;
-    text-shadow: none;
-  }
-  &.button, &.entry {
-    background-image: none;
-    border-image: none;
-    &:hover {
-      background-image: none;
-      border-image: none;
-    }
-    &:active {
-      background-image: none;
-      border-image: none;
-      &:focused {
-        background-image: none;
-        border-image: none;
-      }
-    }
-  }
-  &.button:focused {
-    border-color: transparentize(white, 0.9);
     border-width: 1px;
-    border-style: solid;
-    color: white;
-  }
-  &.entry {
-    &:focused {
-      border-color: transparentize(white, 0.9);
-      border-width: 1px;
-      border-style: solid;
-      color: white;
-    }
-    &:selected {
-      background-color: transparentize(white, 0.2);
-    }
-    &:active {
-      -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
-      animation: dashentry_spinner 1s infinite linear;
-    }
-  }
-  &.option-button {
-    padding: 2px;
-    background: none;
-    border: 0;
-  }
-  &.toggle-button {
-    background: none;
-    border-width: 0;
-    &.selected {
-      background-color: transparentize(black, 0.3);
-      border-width: 1px;
-    }
   }
 }
 

--- a/common/gtk-3.0/3.18/sass/_unity.scss
+++ b/common/gtk-3.0/3.18/sass/_unity.scss
@@ -82,9 +82,13 @@ UnityPanelWidget,
 }
 
 .lightdm.menubar {
-  color: white;
+  color: transparentize(white, 0.2);
   background-image: none;
   background-color: transparentize(black, 0.5);
+
+  & > .menuitem {
+    padding: 2px 6px;
+  }
 }
 
 .lightdm-combo.combobox-entry .button,
@@ -96,7 +100,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: transparentize(black, 0.7);
   border-color: transparentize(white, 0.6);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none;

--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -3466,6 +3466,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: #4a4f61;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -3579,6 +3579,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3589,7 +3590,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -3475,19 +3475,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: #4a4f61;
+  background-color: rgba(64, 71, 86, 0.97);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3496,34 +3503,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -3579,9 +3579,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3592,7 +3594,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.20/gtk-darker.css
+++ b/common/gtk-3.0/3.20/gtk-darker.css
@@ -3577,9 +3577,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3590,7 +3592,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.20/gtk-darker.css
+++ b/common/gtk-3.0/3.20/gtk-darker.css
@@ -3474,19 +3474,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: rgba(64, 71, 86, 0.97);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3495,34 +3502,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.20/gtk-darker.css
+++ b/common/gtk-3.0/3.20/gtk-darker.css
@@ -3577,6 +3577,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3587,7 +3588,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.20/gtk-darker.css
+++ b/common/gtk-3.0/3.20/gtk-darker.css
@@ -3465,6 +3465,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.20/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.20/gtk-solid-dark.css
@@ -3466,6 +3466,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: #4a4f61;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.20/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.20/gtk-solid-dark.css
@@ -3475,19 +3475,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: #4a4f61;
+  background-color: #404756;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3496,34 +3503,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.20/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.20/gtk-solid-dark.css
@@ -3579,6 +3579,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3589,7 +3590,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.20/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.20/gtk-solid-dark.css
@@ -3579,9 +3579,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3592,7 +3594,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.20/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.20/gtk-solid-darker.css
@@ -3577,9 +3577,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3590,7 +3592,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.20/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.20/gtk-solid-darker.css
@@ -3577,6 +3577,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3587,7 +3588,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.20/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.20/gtk-solid-darker.css
@@ -3474,19 +3474,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: #404756;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3495,34 +3502,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.20/gtk-solid-darker.css
+++ b/common/gtk-3.0/3.20/gtk-solid-darker.css
@@ -3465,6 +3465,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.20/gtk-solid.css
+++ b/common/gtk-3.0/3.20/gtk-solid.css
@@ -3581,6 +3581,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3591,7 +3592,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.20/gtk-solid.css
+++ b/common/gtk-3.0/3.20/gtk-solid.css
@@ -3581,9 +3581,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3594,7 +3596,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.20/gtk-solid.css
+++ b/common/gtk-3.0/3.20/gtk-solid.css
@@ -3469,6 +3469,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.20/gtk-solid.css
+++ b/common/gtk-3.0/3.20/gtk-solid.css
@@ -3478,19 +3478,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: #fdfdfe;
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3499,34 +3506,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.20/gtk.css
+++ b/common/gtk-3.0/3.20/gtk.css
@@ -3581,6 +3581,7 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
@@ -3591,7 +3592,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.20/gtk.css
+++ b/common/gtk-3.0/3.20/gtk.css
@@ -3478,19 +3478,26 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm-combo .menu {
-  background-color: white;
+  background-color: rgba(253, 253, 254, 0.95);
   border-radius: 0px;
   padding: 0px;
   color: white; }
 
-.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
   color: white; }
 
 .lightdm.menubar {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
 
-.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
   background-image: none;
   background-color: rgba(0, 0, 0, 0.7);
   border-color: rgba(255, 255, 255, 0.4);
@@ -3499,34 +3506,18 @@ UnityPanelWidget,
   color: white;
   text-shadow: none; }
 
-.lightdm.button, .lightdm.entry {
-  background-image: none;
-  background-color: rgba(0, 0, 0, 0.7);
-  border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
-  padding: 7px;
-  color: white;
-  text-shadow: none; }
-
-.lightdm.button, .lightdm.entry {
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
   background-image: none;
   border-image: none; }
-  .lightdm.button:hover, .lightdm.entry:hover {
-    background-image: none;
-    border-image: none; }
-  .lightdm.button:active, .lightdm.entry:active {
-    background-image: none;
-    border-image: none; }
-    .lightdm.button:active:focused, .lightdm.entry:active:focused {
-      background-image: none;
-      border-image: none; }
 
-.lightdm.button:focused {
-  border-color: rgba(255, 255, 255, 0.1);
-  border-width: 1px;
-  border-style: solid;
-  color: white; }
-
+.lightdm.button:focused,
 .lightdm.entry:focused {
   border-color: rgba(255, 255, 255, 0.1);
   border-width: 1px;

--- a/common/gtk-3.0/3.20/gtk.css
+++ b/common/gtk-3.0/3.20/gtk.css
@@ -3581,9 +3581,11 @@ UnityPanelWidget,
   color: white; }
 
 .lightdm.menubar {
-  color: white;
+  color: rgba(255, 255, 255, 0.8);
   background-image: none;
   background-color: rgba(0, 0, 0, 0.5); }
+  .lightdm.menubar > .menuitem {
+    padding: 2px 6px; }
 
 .lightdm-combo.combobox-entry .button,
 .lightdm-combo .cell,
@@ -3594,7 +3596,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: rgba(0, 0, 0, 0.3);
   border-color: rgba(255, 255, 255, 0.4);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none; }

--- a/common/gtk-3.0/3.20/gtk.css
+++ b/common/gtk-3.0/3.20/gtk.css
@@ -3469,6 +3469,93 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, #5294E2);
   border-bottom: none; }
 
+.lightdm.menu {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-color: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+  color: white; }
+
+.lightdm-combo .menu {
+  background-color: white;
+  border-radius: 0px;
+  padding: 0px;
+  color: white; }
+
+.lightdm.menu .menuitem *, .lightdm.menu .menuitem.check:active, .lightdm.menu .menuitem.radio:active {
+  color: white; }
+
+.lightdm.menubar {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.5); }
+
+.lightdm-combo.combobox-entry .button, .lightdm-combo .cell, .lightdm-combo .button, .lightdm-combo .entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none; }
+
+.lightdm.button, .lightdm.entry {
+  background-image: none;
+  border-image: none; }
+  .lightdm.button:hover, .lightdm.entry:hover {
+    background-image: none;
+    border-image: none; }
+  .lightdm.button:active, .lightdm.entry:active {
+    background-image: none;
+    border-image: none; }
+    .lightdm.button:active:focused, .lightdm.entry:active:focused {
+      background-image: none;
+      border-image: none; }
+
+.lightdm.button:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:focused {
+  border-color: rgba(255, 255, 255, 0.1);
+  border-width: 1px;
+  border-style: solid;
+  color: white; }
+
+.lightdm.entry:selected {
+  background-color: rgba(255, 255, 255, 0.8); }
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear; }
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0; }
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0; }
+  .lightdm.toggle-button.selected {
+    background-color: rgba(0, 0, 0, 0.7);
+    border-width: 1px; }
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn); } }
+
 .overlay-bar {
   background-color: #5294E2;
   border-color: #5294E2;

--- a/common/gtk-3.0/3.20/sass/_unity.scss
+++ b/common/gtk-3.0/3.20/sass/_unity.scss
@@ -61,15 +61,15 @@ UnityPanelWidget,
 // Unity Greeter
 .lightdm.menu {
   background-image: none;
-  background-color: alpha(black, 0.6);
-  border-color: alpha(white, 0.2);
+  background-color: transparentize(black, 0.6);
+  border-color: transparentize(white, 0.2);
   border-radius: 4px;
   padding: 1px;
   color: white;
 }
 
 .lightdm-combo .menu {
-  background-color: shade($bg_color, 1.08);
+  background-color: lighten($bg_color, 8);
   border-radius: 0px;
   padding: 0px;
   color: white;
@@ -83,15 +83,15 @@ UnityPanelWidget,
   }
   &.menubar {
     background-image: none;
-    background-color: alpha(black, 0.5);
+    background-color: transparentize(black, 0.5);
   }
 }
 
 .lightdm-combo {
   &.combobox-entry .button, .cell, .button, .entry {
     background-image: none;
-    background-color: alpha(black, 0.3);
-    border-color: alpha(white, 0.6);
+    background-color: transparentize(black, 0.3);
+    border-color: transparentize(white, 0.6);
     border-radius: 5px;
     padding: 7px;
     color: white;
@@ -102,8 +102,8 @@ UnityPanelWidget,
 .lightdm {
   &.button, &.entry {
     background-image: none;
-    background-color: alpha(black, 0.3);
-    border-color: alpha(white, 0.6);
+    background-color: transparentize(black, 0.3);
+    border-color: transparentize(white, 0.6);
     border-radius: 5px;
     padding: 7px;
     color: white;
@@ -126,20 +126,20 @@ UnityPanelWidget,
     }
   }
   &.button:focused {
-    border-color: alpha(white, 0.9);
+    border-color: transparentize(white, 0.9);
     border-width: 1px;
     border-style: solid;
     color: white;
   }
   &.entry {
     &:focused {
-      border-color: alpha(white, 0.9);
+      border-color: transparentize(white, 0.9);
       border-width: 1px;
       border-style: solid;
       color: white;
     }
     &:selected {
-      background-color: alpha(white, 0.2);
+      background-color: transparentize(white, 0.2);
     }
     &:active {
       -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
@@ -155,7 +155,7 @@ UnityPanelWidget,
     background: none;
     border-width: 0;
     &.selected {
-      background-color: alpha(black, 0.3);
+      background-color: transparentize(black, 0.3);
       border-width: 1px;
     }
   }

--- a/common/gtk-3.0/3.20/sass/_unity.scss
+++ b/common/gtk-3.0/3.20/sass/_unity.scss
@@ -57,3 +57,112 @@ UnityPanelWidget,
   background-image: linear-gradient(to bottom, $selected_bg_color);
   border-bottom: none;
 }
+
+// Unity Greeter
+.lightdm.menu {
+  background-image: none;
+  background-color: alpha(black, 0.6);
+  border-color: alpha(white, 0.2);
+  border-radius: 4px;
+  padding: 1px;
+  color: white;
+}
+
+.lightdm-combo .menu {
+  background-color: shade($bg_color, 1.08);
+  border-radius: 0px;
+  padding: 0px;
+  color: white;
+}
+
+.lightdm {
+  &.menu .menuitem {
+    *, &.check:active, &.radio:active {
+      color: white;
+    }
+  }
+  &.menubar {
+    background-image: none;
+    background-color: alpha(black, 0.5);
+  }
+}
+
+.lightdm-combo {
+  &.combobox-entry .button, .cell, .button, .entry {
+    background-image: none;
+    background-color: alpha(black, 0.3);
+    border-color: alpha(white, 0.6);
+    border-radius: 5px;
+    padding: 7px;
+    color: white;
+    text-shadow: none;
+  }
+}
+
+.lightdm {
+  &.button, &.entry {
+    background-image: none;
+    background-color: alpha(black, 0.3);
+    border-color: alpha(white, 0.6);
+    border-radius: 5px;
+    padding: 7px;
+    color: white;
+    text-shadow: none;
+  }
+  &.button, &.entry {
+    background-image: none;
+    border-image: none;
+    &:hover {
+      background-image: none;
+      border-image: none;
+    }
+    &:active {
+      background-image: none;
+      border-image: none;
+      &:focused {
+        background-image: none;
+        border-image: none;
+      }
+    }
+  }
+  &.button:focused {
+    border-color: alpha(white, 0.9);
+    border-width: 1px;
+    border-style: solid;
+    color: white;
+  }
+  &.entry {
+    &:focused {
+      border-color: alpha(white, 0.9);
+      border-width: 1px;
+      border-style: solid;
+      color: white;
+    }
+    &:selected {
+      background-color: alpha(white, 0.2);
+    }
+    &:active {
+      -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+      animation: dashentry_spinner 1s infinite linear;
+    }
+  }
+  &.option-button {
+    padding: 2px;
+    background: none;
+    border: 0;
+  }
+  &.toggle-button {
+    background: none;
+    border-width: 0;
+    &.selected {
+      background-color: alpha(black, 0.3);
+      border-width: 1px;
+    }
+  }
+}
+
+@keyframes dashentry_spinner {
+  to {
+    -gtk-icon-transform: rotate(1turn);
+  }
+}

--- a/common/gtk-3.0/3.20/sass/_unity.scss
+++ b/common/gtk-3.0/3.20/sass/_unity.scss
@@ -82,6 +82,7 @@ UnityPanelWidget,
 }
 
 .lightdm.menubar {
+  color: white;
   background-image: none;
   background-color: transparentize(black, 0.5);
 }
@@ -93,7 +94,7 @@ UnityPanelWidget,
 .lightdm.button,
 .lightdm.entry {
   background-image: none;
-  background-color: transparentize(black, 0.3);
+  background-color: transparentize(black, 0.7);
   border-color: transparentize(white, 0.6);
   border-radius: 5px;
   padding: 7px;

--- a/common/gtk-3.0/3.20/sass/_unity.scss
+++ b/common/gtk-3.0/3.20/sass/_unity.scss
@@ -69,95 +69,80 @@ UnityPanelWidget,
 }
 
 .lightdm-combo .menu {
-  background-color: lighten($bg_color, 8);
+  background-color: lighten($header_bg, 8);
   border-radius: 0px;
   padding: 0px;
   color: white;
 }
 
-.lightdm {
-  &.menu .menuitem {
-    *, &.check:active, &.radio:active {
-      color: white;
-    }
-  }
-  &.menubar {
-    background-image: none;
-    background-color: transparentize(black, 0.5);
-  }
+.lightdm.menu .menuitem *,
+.lightdm.menu .menuitem.check:active,
+.lightdm.menu .menuitem.radio:active {
+  color: white;
 }
 
-.lightdm-combo {
-  &.combobox-entry .button, .cell, .button, .entry {
-    background-image: none;
-    background-color: transparentize(black, 0.3);
-    border-color: transparentize(white, 0.6);
-    border-radius: 5px;
-    padding: 7px;
-    color: white;
-    text-shadow: none;
-  }
+.lightdm.menubar {
+  background-image: none;
+  background-color: transparentize(black, 0.5);
 }
 
-.lightdm {
-  &.button, &.entry {
-    background-image: none;
+.lightdm-combo.combobox-entry .button,
+.lightdm-combo .cell,
+.lightdm-combo .button,
+.lightdm-combo .entry,
+.lightdm.button,
+.lightdm.entry {
+  background-image: none;
+  background-color: transparentize(black, 0.3);
+  border-color: transparentize(white, 0.6);
+  border-radius: 5px;
+  padding: 7px;
+  color: white;
+  text-shadow: none;
+}
+
+.lightdm.button,
+.lightdm.button:hover,
+.lightdm.button:active,
+.lightdm.button:active:focused,
+.lightdm.entry,
+.lightdm.entry:hover,
+.lightdm.entry:active,
+.lightdm.entry:active:focused {
+  background-image: none;
+  border-image: none;
+}
+
+.lightdm.button:focused,
+.lightdm.entry:focused {
+  border-color: transparentize(white, 0.9);
+  border-width: 1px;
+  border-style: solid;
+  color: white;
+}
+
+.lightdm.entry:selected {
+  background-color: transparentize(white, 0.2);
+}
+
+.lightdm.entry:active {
+  -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
+  animation: dashentry_spinner 1s infinite linear;
+}
+
+.lightdm.option-button {
+  padding: 2px;
+  background: none;
+  border: 0;
+}
+
+.lightdm.toggle-button {
+  background: none;
+  border-width: 0;
+
+  &.selected {
     background-color: transparentize(black, 0.3);
-    border-color: transparentize(white, 0.6);
-    border-radius: 5px;
-    padding: 7px;
-    color: white;
-    text-shadow: none;
-  }
-  &.button, &.entry {
-    background-image: none;
-    border-image: none;
-    &:hover {
-      background-image: none;
-      border-image: none;
-    }
-    &:active {
-      background-image: none;
-      border-image: none;
-      &:focused {
-        background-image: none;
-        border-image: none;
-      }
-    }
-  }
-  &.button:focused {
-    border-color: transparentize(white, 0.9);
     border-width: 1px;
-    border-style: solid;
-    color: white;
-  }
-  &.entry {
-    &:focused {
-      border-color: transparentize(white, 0.9);
-      border-width: 1px;
-      border-style: solid;
-      color: white;
-    }
-    &:selected {
-      background-color: transparentize(white, 0.2);
-    }
-    &:active {
-      -gtk-icon-source: -gtk-icontheme("process-working-symbolic");
-      animation: dashentry_spinner 1s infinite linear;
-    }
-  }
-  &.option-button {
-    padding: 2px;
-    background: none;
-    border: 0;
-  }
-  &.toggle-button {
-    background: none;
-    border-width: 0;
-    &.selected {
-      background-color: transparentize(black, 0.3);
-      border-width: 1px;
-    }
   }
 }
 

--- a/common/gtk-3.0/3.20/sass/_unity.scss
+++ b/common/gtk-3.0/3.20/sass/_unity.scss
@@ -82,9 +82,13 @@ UnityPanelWidget,
 }
 
 .lightdm.menubar {
-  color: white;
+  color: transparentize(white, 0.2);
   background-image: none;
   background-color: transparentize(black, 0.5);
+
+  & > .menuitem {
+    padding: 2px 6px;
+  }
 }
 
 .lightdm-combo.combobox-entry .button,
@@ -96,7 +100,7 @@ UnityPanelWidget,
   background-image: none;
   background-color: transparentize(black, 0.7);
   border-color: transparentize(white, 0.6);
-  border-radius: 5px;
+  border-radius: 10px;
   padding: 7px;
   color: white;
   text-shadow: none;


### PR DESCRIPTION
Arc (and most GTK themes not bundled with Ubuntu) leaves **Unity Greeter** (Ubuntu's default LightDM greeter) unthemed. :worried: Like this:

![ArcThemedUnityGreeter](https://cloud.githubusercontent.com/assets/3755396/14580874/b1d37178-03fa-11e6-8183-f396cee0532b.png)

*budgie-remix* is switching to Unity Greeter and wanted to ensure it looks good on Arc theme. So, I just copied the contents of `unity-greeter.css` from [Ubuntu Themes upstream repo](https://bazaar.launchpad.net/~ubuntu-art-pkg/ubuntu-themes/trunk/view/head:/Ambiance/gtk-3.0/apps/unity-greeter.css), converted to SASS using [css2sass](https://css2sass.herokuapp.com) and added it to the existing `_unity.scss` in Arc. :relaxed: I added the same content to all 4 versions (GTK3.20 to GTK3.14), coz as u can see in [unity-greeter's file history](https://bazaar.launchpad.net/~ubuntu-art-pkg/ubuntu-themes/trunk/changes?filter_file_id=unitygreeter.css-20120206150958-niclp6mwf7mblqej-1), it wasn't changed since Ubuntu 15.04 (which used GTK3.14). With the addition of Unity Greeter CSS code (and changing background via gsettings) Unity Greeter on Arc looks like this:

![ArcUnthemedUnityGreeter](https://cloud.githubusercontent.com/assets/3755396/14580875/c60ff274-03fa-11e6-934a-e03c72b89994.png)