### PR TITLE
Make xfce4-panel icons bigger and fix background color of progress bars

### DIFF
--- a/common/gtk-2.0/panel.rc
+++ b/common/gtk-2.0/panel.rc
@@ -1,10 +1,11 @@
 style "theme-panel" {
 
+  xthickness = 2
   ythickness = 0
 
   bg[NORMAL] = "#2B2E37"
-  bg[ACTIVE] = @selected_bg_color
-  bg[PRELIGHT] = shade(1.1, @selected_bg_color)
+  bg[ACTIVE] = shade(1.45, "#2B2E37")
+  bg[PRELIGHT] = shade(0.9, @selected_bg_color)
   bg[SELECTED] = @selected_bg_color
 
   fg[NORMAL] = "#BAC3CF"
@@ -26,7 +27,6 @@ style "theme-panel" {
     gradient_shades = {1.0,1.0,1.0,1.0}
     textstyle = 0
     contrast = 0.0
-    textstyle = 0
   }
 }
 
@@ -93,6 +93,31 @@ style "workspace-switcher" = "theme-panel" {
   bg[SELECTED] = @selected_bg_color
 }
 
+style "window-buttons" = "theme-panel"
+{
+  xthickness = 3
+  ythickness = 3
+
+  bg[ACTIVE] = shade(0.75, @selected_bg_color)
+  bg[PRELIGHT] = shade(0.9, @selected_bg_color)
+  bg[SELECTED] = @selected_bg_color
+
+  fg[NORMAL] = shade(0.7, @base_color)
+  fg[ACTIVE] = @base_color
+  fg[PRELIGHT] = @base_color
+
+  engine "murrine" {
+    reliefstyle = 0
+    glazestyle = 0
+    glow_shade = 1.0
+    highlight_shade = 1.0
+    roundness = 0
+    gradient_shades = {1.0,1.0,1.0,1.0}
+    textstyle = 0
+    contrast = 0.0
+  }
+}
+
 style "indicator" = "theme-panel" {
   xthickness = 0
   ythickness = 0
@@ -151,3 +176,4 @@ widget "*PanelApplet*"                                style "theme-panel-text"
 # Override general panel-style with specific plugin-styles
 widget "*indicator-applet*"                           style "indicator"
 widget "*indicator-button*"                           style "indicator"
+widget "*XfceTasklist*"                               style "window-buttons"


### PR DESCRIPTION
## Problems

Background for progress bars looks like a selection:
![image](https://cloud.githubusercontent.com/assets/1516236/14901109/8596d9d2-0d9c-11e6-9092-859ed734fbd4.png)

This also affects the volume bar on Xfce (volume bar and the background are the same):
![image](https://cloud.githubusercontent.com/assets/1516236/14902258/8035de06-0da2-11e6-9952-1d5556a36b5d.png)

Button icons are too small:
![image](https://cloud.githubusercontent.com/assets/1516236/14901145/a694ac7c-0d9c-11e6-8470-480e09c5b4e6.png)


## Solutions

This commit fixes by changing the active shade for all widgets.

Progress bars look a lot nicer:
![image](https://cloud.githubusercontent.com/assets/1516236/14901165/cba9b6a6-0d9c-11e6-8afe-b3855eef9782.png)

This fixes the volume bar:
![image](https://cloud.githubusercontent.com/assets/1516236/14902078/6ddbc956-0da1-11e6-999e-9af9dcfb87ac.png)

Separate style was added specifically for window buttons, so they are still blue when selected. It uses a bit darker color for better consistency with selection colors in other places.

Also x/y thickness was changed, so icons are bigger.
![image](https://cloud.githubusercontent.com/assets/1516236/14902165/f63641dc-0da1-11e6-9460-9da974f568d5.png)

Icon size was taken as is from default Xfce themes, so many will be familiar with this icon size.

This fixes an issue #496 (small icons) and is an alternative to PR #463 (volume bar).