### PR TITLE
Add common AUR package issue and fix

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,6 +12,8 @@
   - Check if you have the Murrine GTK engine and `gnome-themes-standard` installed.
 - My GTK apps have a transparent background in Ubuntu.
   - Run this in terminal: `gsettings set com.canonical.desktop.interface scrollbar-mode normal`.
+- On Arch Linux the AUR package won't build [[gtk-theme-arc-git](https://aur.archlinux.org/packages/gtk-theme-arc-git/)/[gtk-theme-arc](https://aur.archlinux.org/packages/gtk-theme-arc/)]
+  - Ensure you have the "[base-devel](https://www.archlinux.org/groups/x86_64/base-devel/)" package installed before you build packages from AUR.
 
 **Mark those:**
 


### PR DESCRIPTION
A common issue for new Arch Linux users is them forgetting to install the 'base-devel' package group which includes essential packages like 'pkg-config'. By default it's assumed they've installed it however many forget to.