### PR TITLE
Fix to misplaced desktop labels after latest murrine engine update

### DIFF
--- a/common/gtk-2.0/main.rc
+++ b/common/gtk-2.0/main.rc
@@ -2205,7 +2205,7 @@ style "xfdesktop-icon-view" {
   fg[ACTIVE] = @selected_fg_color
 
   engine "murrine" {
-    textstyle = 5
+    textstyle = 0
     text_shade = 0.05
   }
 }


### PR DESCRIPTION
After the latest update of the murrine-engine I had this issue on Xfce: the labels of the icons in the Desktop were misplaced ([pic](http://i.imgur.com/dkMqhn2.png)).

The same issue was present on Numix and it was resolved in the same manner ([fix](https://github.com/numixproject/numix-gtk-theme/commit/76321bb4f7ee9c6edd1fe4a4dafe3b7abf0fa4d7)).