### PR TITLE
Fix slider for gnome-shell

### DIFF
--- a/common/gnome-shell/3.14/gnome-shell-dark.css
+++ b/common/gnome-shell/3.14/gnome-shell-dark.css
@@ -189,7 +189,7 @@ StScrollBar {
   -slider-active-background-color: #5294E2;
   -slider-active-border-color: transparent;
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   -slider-handle-border-color: transparent;
   -slider-handle-border-width: 0;
   height: 18px;

--- a/common/gnome-shell/3.14/gnome-shell.css
+++ b/common/gnome-shell/3.14/gnome-shell.css
@@ -189,7 +189,7 @@ StScrollBar {
   -slider-active-background-color: #5294E2;
   -slider-active-border-color: transparent;
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   -slider-handle-border-color: transparent;
   -slider-handle-border-width: 0;
   height: 18px;

--- a/common/gnome-shell/3.14/sass/_common.scss
+++ b/common/gnome-shell/3.14/sass/_common.scss
@@ -169,7 +169,7 @@ StScrollBar {
   -slider-active-background-color: $selected_bg_color;        //active trough fill
   -slider-active-border-color: transparentize(black, 1);      //active trough border
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   -slider-handle-border-color: transparent;
   -slider-handle-border-width: 0;
   height: 18px;

--- a/common/gnome-shell/3.16/gnome-shell-dark.css
+++ b/common/gnome-shell/3.16/gnome-shell-dark.css
@@ -150,7 +150,7 @@ StScrollBar {
   -slider-active-background-color: #5294E2;
   -slider-active-border-color: transparent;
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;

--- a/common/gnome-shell/3.16/gnome-shell.css
+++ b/common/gnome-shell/3.16/gnome-shell.css
@@ -150,7 +150,7 @@ StScrollBar {
   -slider-active-background-color: #5294E2;
   -slider-active-border-color: transparent;
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;

--- a/common/gnome-shell/3.16/sass/_common.scss
+++ b/common/gnome-shell/3.16/sass/_common.scss
@@ -142,7 +142,7 @@ StScrollBar {
   -slider-active-background-color: $selected_bg_color;        //active trough fill
   -slider-active-border-color: transparentize(black, 1);      //active trough border
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;

--- a/common/gnome-shell/3.18/gnome-shell-dark.css
+++ b/common/gnome-shell/3.18/gnome-shell-dark.css
@@ -124,7 +124,7 @@ StScrollBar {
   -slider-active-background-color: #5294E2;
   -slider-active-border-color: transparent;
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;

--- a/common/gnome-shell/3.18/gnome-shell.css
+++ b/common/gnome-shell/3.18/gnome-shell.css
@@ -124,7 +124,7 @@ StScrollBar {
   -slider-active-background-color: #5294E2;
   -slider-active-border-color: transparent;
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -143,7 +143,7 @@ StScrollBar {
   -slider-active-background-color: $selected_bg_color;        //active trough fill
   -slider-active-border-color: transparentize(black, 1);      //active trough border
   -slider-border-width: 0;
-  -slider-handle-radius: 4px;
+  -slider-handle-radius: 0px;
   height: 18px;
   border: 0 solid transparent;
   border-right-width: 1px;


### PR DESCRIPTION
The handle radius was preventing the slider from reaching either extreme.
Close #399.