### PR TITLE
fix switcher list subitems jumping around

### DIFF
--- a/common/gnome-shell/3.14/gnome-shell-dark.css
+++ b/common/gnome-shell/3.14/gnome-shell-dark.css
@@ -572,6 +572,7 @@ StScrollBar {
     spacing: 8px; }
   .switcher-list .item-box {
     padding: 8px;
+    border: 1px solid transparent;
     border-radius: 2px; }
     .switcher-list .item-box:outlined {
       padding: 8px;

--- a/common/gnome-shell/3.14/gnome-shell.css
+++ b/common/gnome-shell/3.14/gnome-shell.css
@@ -572,6 +572,7 @@ StScrollBar {
     spacing: 8px; }
   .switcher-list .item-box {
     padding: 8px;
+    border: 1px solid transparent;
     border-radius: 2px; }
     .switcher-list .item-box:outlined {
       padding: 8px;

--- a/common/gnome-shell/3.16/gnome-shell-dark.css
+++ b/common/gnome-shell/3.16/gnome-shell-dark.css
@@ -519,6 +519,7 @@ StScrollBar {
     spacing: 8px; }
   .switcher-list .item-box {
     padding: 8px;
+    border: 1px solid transparent;
     border-radius: 2px; }
     .switcher-list .item-box:outlined {
       padding: 8px;

--- a/common/gnome-shell/3.16/gnome-shell.css
+++ b/common/gnome-shell/3.16/gnome-shell.css
@@ -519,6 +519,7 @@ StScrollBar {
     spacing: 8px; }
   .switcher-list .item-box {
     padding: 8px;
+    border: 1px solid transparent;
     border-radius: 2px; }
     .switcher-list .item-box:outlined {
       padding: 8px;

--- a/common/gnome-shell/3.18/gnome-shell-dark.css
+++ b/common/gnome-shell/3.18/gnome-shell-dark.css
@@ -548,6 +548,7 @@ StScrollBar {
     spacing: 8px; }
   .switcher-list .item-box {
     padding: 8px;
+    border: 1px solid transparent;
     border-radius: 2px; }
     .switcher-list .item-box:outlined {
       padding: 8px;

--- a/common/gnome-shell/3.18/gnome-shell.css
+++ b/common/gnome-shell/3.18/gnome-shell.css
@@ -548,6 +548,7 @@ StScrollBar {
     spacing: 8px; }
   .switcher-list .item-box {
     padding: 8px;
+    border: 1px solid transparent;
     border-radius: 2px; }
     .switcher-list .item-box:outlined {
       padding: 8px;


### PR DESCRIPTION
Currently the added 1px border for `.switcher-list .item-box:outlined` and `.switcher-list .item-box:selected`items leads to the parent frame changing size and items jumping around when entering a frame which has no selected items yet with the mouse and hovering an item.

The issue can be reproduced as follows:
* open up multiple window instances of one application (e.g. file manager)
* press [Alt]+[Tab] to bring up the switcher list, keep holding [Alt]
* hover the file manager entry item
  * the white arrow pointing down below the icon will shift it's vertical position by 1px
  * a subframe will popup below, listing the individual windows
* now move the mouse over one of the listed subwindows
  * the subframe containing the thumbnails will change it's size and the thumbnails will move around because the hovered items gains a 1px border, effectively changing the size of the parent container

The proposed fix in the merge request adds a 1px invisible border to unselected `.switcher-list` items, preparing the correct alignment and frame sizing for the visible borders in the `outlined` or `selected` states. This also fixes the downwards pointing arrow shifting its position on item hover.

The issue has been observed and the fix tested on Debian Jessie 8.5 running GNOME Shell 3.14.4.
