### PR TITLE
Don't require GTK+3 at configure time when it's not needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ ARC_ENABLE([UNITY],         [unity],         [Unity],         [disable])
 ARC_ENABLE([XFWM],          [xfwm],          [XFWM],          [disable])
 ARC_ENABLE([TRANSPARENCY],  [transparency],  [transparency],  [disable])
 
-ARC_GNOME
+AS_IF([test "x$ENABLE_GNOME_SHELL$ENABLE_GTK3" != xnono], [ARC_GNOME])
 
 AC_CONFIG_FILES([
     common/Makefile


### PR DESCRIPTION
It's not needed when --disable-gtk3 --disable-gnome-shell is given.

This fix may not be needed if #436 goes ahead, depending on how you end up doing it. I would like to see that because Gentoo has multiple GTK+3 versions in its package tree and you would need to manually reinstall this theme after updating.