### PR TITLE
Implement automatic precompilation of the theme

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -190,6 +190,23 @@ endif # ENABLE_DARK
 
 endif #!ENABLE_TRANSPARENCY
 
+
+	cd $(srcdir)/gtk-3.0/$(GNOME_VERSION) && cp -R \
+		compile-gresources.sh \
+		$(ithemedir)/gtk-3.0/compile-gresources.sh
+
+	cd $(srcdir)/gtk-3.0/$(GNOME_VERSION) && cp -R \
+		compile-gresources.sh \
+		$(ithemedarkdir)/gtk-3.0/compile-gresources.sh
+
+	cd $(srcdir)/gtk-3.0/$(GNOME_VERSION) && cp -R \
+		compile-gresources.sh \
+		$(ithemedarkerdir)/gtk-3.0/compile-gresources.sh
+
+	cd $(ithemedir)/gtk-3.0/ && ./compile-gresources.sh
+	cd $(ithemedarkdir)/gtk-3.0/ && ./compile-gresources.sh
+	cd $(ithemedarkerdir)/gtk-3.0/ && ./compile-gresources.sh
+
 endif # ENABLE_GTK3
 
 

--- a/common/gtk-3.0/3.20/compile-gresources.sh
+++ b/common/gtk-3.0/3.20/compile-gresources.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Setup
+mv gtk.css gtk-main.css
+mv gtk-dark.css gtk-main-dark.css
+
+
+# Get processed assets lists
+ls ./assets | sort > temp_asset_list.txt
+
+
+# Build dynamic gresouce xml spec from css and assets
+read -d '' RES_PART1 <<"EOF"
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+<gresource prefix="/org/gnome/arc-theme">
+EOF
+echo $RES_PART1 > gtk.gresource.xml
+
+
+# Import as nodes the file assets
+xargs -i echo '<file preprocess="to-pixdata">assets/{}</file>' >> gtk.gresource.xml < temp_asset_list.txt
+rm -f temp_asset_list.txt
+
+
+# Write the css file information to the template
+read -d '' RES_PART2 <<"EOF"
+<file>gtk-main.css</file>
+<file>gtk-main-dark.css</file>
+</gresource>
+</gresources>
+EOF
+echo $RES_PART2 >> gtk.gresource.xml
+
+# Compile the gresource file
+glib-compile-resources gtk.gresource.xml
+echo '@import url("resource:///org/gnome/arc-theme/gtk-main.css");' > gtk.css
+echo '@import url("resource:///org/gnome/arc-theme/gtk-main-dark.css");' > gtk-dark.css
+
+
+# Cleanup
+rm -rf assets
+rm -f gtk.gresource.xml
+rm -f gtk-main.css
+rm -f gtk-main-dark.css
+rm -f compile-gresources.sh


### PR DESCRIPTION
Following the path of Adwaita, this commit implements the automation to
automatically precompile the GTK3 theme versions to gresource binary
files, to improve performance of theme rendering, and avoid unnecessary
re-read and re-parsing of the theme on every app run.

Given that the theme is coded in sass to begin with directly altering it
is not a reasonable thing to do, and so we don't loose anything by
having the installed theme in binary form, specially when accessing the
sources is easy enough.
