### PR TITLE
Fix mixed quote types in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
-var gulp        = require("gulp");
-var sass        = require("gulp-sass");
+var gulp        = require('gulp');
+var sass        = require('gulp-sass');
 var rename      = require('gulp-rename');
 
 gulp.task('sass', function () {
@@ -12,7 +12,7 @@ gulp.task('sass', function () {
             }
         }))
         .pipe(rename(function (path) {
-            path.dirname += "/../";
+            path.dirname += '/../';
         }))
         .pipe(gulp.dest('./'))
 });


### PR DESCRIPTION
This fixes the mixed usage of double and single quotes.
I did notice that there is a `notify()` function, which is not defined. Is that supposed to be node-notify?