### PR TITLE
Fixing bold font in GTK3 XFCE4 Panel Plugin Menus

### DIFF
--- a/common/gtk-3.0/3.20/gtk-dark.css
+++ b/common/gtk-3.0/3.20/gtk-dark.css
@@ -3515,7 +3515,10 @@ panel-toplevel.background na-tray-applet {
 .xfce4-panel.panel {
   background-color: rgba(43, 46, 55, 0.95);
   text-shadow: none;
+  font-weight: bold;
   -gtk-icon-shadow: none; }
+.xfce4-panel.panel menu {
+  font-weight: normal; }
 
 #tasklist-button {
   color: rgba(186, 195, 207, 0.8);

--- a/common/gtk-3.0/3.20/gtk-darker.css
+++ b/common/gtk-3.0/3.20/gtk-darker.css
@@ -3514,7 +3514,10 @@ panel-toplevel.background na-tray-applet {
 .xfce4-panel.panel {
   background-color: rgba(43, 46, 55, 0.95);
   text-shadow: none;
+  font-weight: bold;
   -gtk-icon-shadow: none; }
+.xfce4-panel.panel menu {
+  font-weight: normal; }
 
 #tasklist-button {
   color: rgba(186, 195, 207, 0.8);

--- a/common/gtk-3.0/3.20/gtk-solid-dark.css
+++ b/common/gtk-3.0/3.20/gtk-solid-dark.css
@@ -3515,7 +3515,10 @@ panel-toplevel.background na-tray-applet {
 .xfce4-panel.panel {
   background-color: #2b2e37;
   text-shadow: none;
+  font-weight: bold;
   -gtk-icon-shadow: none; }
+.xfce4-panel.panel menu {
+  font-weight: normal; }
 
 #tasklist-button {
   color: rgba(186, 195, 207, 0.8);

--- a/common/gtk-3.0/3.20/gtk-solid.css
+++ b/common/gtk-3.0/3.20/gtk-solid.css
@@ -3518,7 +3518,11 @@ panel-toplevel.background na-tray-applet {
 .xfce4-panel.panel {
   background-color: #2b2e37;
   text-shadow: none;
+  font-weight: bold;
   -gtk-icon-shadow: none; }
+.xfce4-panel.panel menu {
+  font-weight: normal; }
+
 
 #tasklist-button {
   color: rgba(186, 195, 207, 0.8);

--- a/common/gtk-3.0/3.20/gtk.css
+++ b/common/gtk-3.0/3.20/gtk.css
@@ -3518,7 +3518,11 @@ panel-toplevel.background na-tray-applet {
 .xfce4-panel.panel {
   background-color: rgba(43, 46, 55, 0.95);
   text-shadow: none;
+  font-weight: bold;
   -gtk-icon-shadow: none; }
+.xfce4-panel.panel menu {
+  font-weight: normal; }
+
 
 #tasklist-button {
   color: rgba(186, 195, 207, 0.8);


### PR DESCRIPTION
I added a CSS Selector for XFCE4 Panel menus, so that a normal font weight in the menu can work with a bold font for the panel. This setting is xfce4-panel specific, so no effect on other components should be possible.

Please merge this patch, since it restores a uniform look to GTK3 (currently bold) and GTK2 (themed correctly) Plugin Menus. XFCE4 is currently moving to GTK3, so the problem will only get more apparent.

A lot of other themes do not seem to be affected since they use a non-bold font in the panel.