### PR TITLE
Support installing transparent and non-transparent variant in parallel

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -1,6 +1,12 @@
+if !ENABLE_TRANSPARENCY
+themedir        = $(datadir)/themes/Arc-solid
+themedarkerdir  = $(datadir)/themes/Arc-Darker-solid
+themedarkdir    = $(datadir)/themes/Arc-Dark-solid
+else
 themedir        = $(datadir)/themes/Arc
 themedarkerdir  = $(datadir)/themes/Arc-Darker
 themedarkdir    = $(datadir)/themes/Arc-Dark
+endif
 
 ithemedir       = $(DESTDIR)$(themedir)
 ithemedarkerdir   = $(DESTDIR)$(themedarkerdir)


### PR DESCRIPTION
By appending `-solid` suffix to non-transparent variant.

This allows distributions to easily pacakge both without conflicts. This will also help with Flatpak being able to match the host theme.

Fedora for example already does this manually.