### PR TITLE
Tweak style for switching windows directly

### DIFF
--- a/common/gnome-shell/3.18/gnome-shell-dark.css
+++ b/common/gnome-shell/3.18/gnome-shell-dark.css
@@ -598,7 +598,9 @@ StScrollBar {
   height: 96px; }
 
 .cycler-highlight {
-  border: 5px solid #5294e2; }
+  border-radius: 3px 3px 0 0;
+  border: 3px solid #5294e2;
+  background-color: rgba(82, 148, 226, 0.35); }
 
 .workspace-switcher {
   background: transparent;

--- a/common/gnome-shell/3.18/gnome-shell.css
+++ b/common/gnome-shell/3.18/gnome-shell.css
@@ -598,7 +598,9 @@ StScrollBar {
   height: 96px; }
 
 .cycler-highlight {
-  border: 5px solid #5294e2; }
+  border-radius: 3px 3px 0 0;
+  border: 3px solid #5294e2;
+  background-color: rgba(82, 148, 226, 0.35); }
 
 .workspace-switcher {
   background: transparent;

--- a/common/gnome-shell/3.18/sass/_common.scss
+++ b/common/gnome-shell/3.18/sass/_common.scss
@@ -814,7 +814,11 @@ StScrollBar {
 //
 //Window Cycler
 //
-.cycler-highlight { border: 5px solid $selected_bg_color; }
+.cycler-highlight {
+  border-radius: 3px 3px 0 0;
+  border: 3px solid $selected_bg_color;
+  background-color: transparentize($selected_bg_color, .65);
+}
 
 //
 // Workspace Switcher
@@ -1294,17 +1298,17 @@ StScrollBar {
     > StIcon {
       icon-size: 18px;
       border-radius: 0px;
-      color: transparent; 
+      color: transparent;
       background-color: transparent;
       background-image: url('#{$asset_path}/misc/message-close.svg');
     }
     &:hover > StIcon {
-      color: transparent; 
+      color: transparent;
       background-color: transparent;
       background-image: url('#{$asset_path}/misc/message-close-hover.svg');
     }
     &:active > StIcon {
-      color: transparent; 
+      color: transparent;
       background-color: transparent;
       background-image: url('#{$asset_path}/misc/message-close-active.svg');
     }
@@ -2106,7 +2110,7 @@ $legacy_icon_size: 24px;
   &:active, &:checked { @include button(osd-active); }
 
   &:grayed { @include button(osd-insensitive); }
-}                             
+}
 
 .keyboard-subkeys { //long press on a key popup
   color: $osd_fg_color;


### PR DESCRIPTION
Styles changed for Gnome Shell >= 3.18

Changes the style of how selected windows are shown when switching directly between windows (default shortcut is Alt+Escape).

Before (switching to nautilus):
![screenshot from 2017-05-20 15-39-39](https://cloud.githubusercontent.com/assets/4040560/26278869/acabfda2-3d72-11e7-9628-6970324fef53.png)

After:
![screenshot from 2017-05-20 15-40-25](https://cloud.githubusercontent.com/assets/4040560/26278875/b93652c0-3d72-11e7-96d4-34055f40f39f.png)

