### PR TITLE
remove margin:auto

### DIFF
--- a/common/cinnamon/cinnamon-dark.css
+++ b/common/cinnamon/cinnamon-dark.css
@@ -964,7 +964,6 @@ StScrollBar {
   -boxpointer-gap: 5px; }
 
 .menu-favorites-box {
-  margin: auto;
   padding: 10px;
   transition-duration: 300;
   background-color: #383C4A;
@@ -975,7 +974,6 @@ StScrollBar {
   border: 1px solid transparent; }
 
 .menu-places-box {
-  margin: auto;
   padding: 10px;
   border: 0px solid red; }
 

--- a/common/cinnamon/cinnamon.css
+++ b/common/cinnamon/cinnamon.css
@@ -964,7 +964,6 @@ StScrollBar {
   -boxpointer-gap: 5px; }
 
 .menu-favorites-box {
-  margin: auto;
   padding: 10px;
   transition-duration: 300;
   background-color: #F5F6F7;
@@ -975,7 +974,6 @@ StScrollBar {
   border: 1px solid transparent; }
 
 .menu-places-box {
-  margin: auto;
   padding: 10px;
   border: 0px solid red; }
 

--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -1099,7 +1099,6 @@ StScrollBar {
 //
 .menu {
   &-favorites-box {
-    margin: auto;
     padding: 10px;
     transition-duration: 300;
     background-color: $bg_color;
@@ -1116,7 +1115,6 @@ StScrollBar {
   &-places {
 
     &-box {
-      margin: auto;
       padding: 10px;
       border: 0px solid red;
     }


### PR DESCRIPTION
This has been removed in cinnamon-3.4

https://github.com/linuxmint/Cinnamon/commit/b579bbe350d1af0089a3a87aff11c254b6ffeb73

```
(cinnamon:1567): St-WARNING **: Ignoring length property that isn't a number at line 967, col 11
```