### PR TITLE
Fixed xfce4 gtk3 panel plugin menus

### DIFF
--- a/common/gtk-3.0/3.20/sass/_applications.scss
+++ b/common/gtk-3.0/3.20/sass/_applications.scss
@@ -632,11 +632,14 @@ panel-toplevel.background {
 // Xfce Panel
 .xfce4-panel.panel {
   background-color: $panel_bg;
-
+  font-weight: bold;
   text-shadow: none;
   -gtk-icon-shadow: none;
 
   button.flat { @extend %panelbutton; }
+}
+.xfce4-panel.panel menu {
+  font-weight: normal;
 }
 
 #tasklist-button {


### PR DESCRIPTION
This should solve bold font issue #749 in xfce4 panel plugin menus for gtk3 widgets as proposed by @xiamaz.