### PR TITLE
Resolve jumping cinnamon panel icons - upstream #852

### DIFF
--- a/common/cinnamon/cinnamon-dark.css
+++ b/common/cinnamon/cinnamon-dark.css
@@ -1305,6 +1305,13 @@ StScrollBar {
     .launcher:hover {
       border-right-width: 1px;
       padding-right: 0; }
+  .panel-bottom .panel-launcher, .panel-bottom
+  .launcher {
+    margin-bottom: 0; }
+  .panel-top .panel-launcher, .panel-top
+  .launcher {
+    margin-top: 0;
+    padding-top: 0; }
 
 #overview-corner {
   background-image: url("common-assets/misc/overview.png"); }

--- a/common/cinnamon/cinnamon.css
+++ b/common/cinnamon/cinnamon.css
@@ -1305,6 +1305,13 @@ StScrollBar {
     .launcher:hover {
       border-right-width: 1px;
       padding-right: 0; }
+  .panel-bottom .panel-launcher, .panel-bottom
+  .launcher {
+    margin-bottom: 0; }
+  .panel-top .panel-launcher, .panel-top
+  .launcher {
+    margin-top: 0;
+    padding-top: 0; }
 
 #overview-corner {
   background-image: url("common-assets/misc/overview.png"); }

--- a/common/cinnamon/sass/_common.scss
+++ b/common/cinnamon/sass/_common.scss
@@ -1512,6 +1512,16 @@ StScrollBar {
     .panel-left & { border-left-width: 1px; padding-left: 0; }
     .panel-right & { border-right-width: 1px; padding-right: 0; }
   }
+
+  .panel-bottom & {
+    margin-bottom: 0;
+  }
+
+  .panel-top & {
+    margin-top: 0;
+    padding-top: 0;
+  }
+
 }
 
 //


### PR DESCRIPTION
resolves https://i.imgur.com/xps3bIc.mp4 (from upstream #852)

tested cinnamon 3.4.6 on Ubuntu 17.10