### PR TITLE
Remove mention of Fedora OBS repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Arc is a flat theme with transparent elements for GTK 3, GTK 2 and GNOME Shell w
 | Arch Linux | `arc-gtk-theme`, [`gtk-theme-arc-git`](https://aur.archlinux.org/packages/gtk-theme-arc-git) (AUR) |
 | Debian 8 | [OBS Repo][obs-repo] |
 | Debian Testing/Unstable | `arc-theme` |
-| Fedora 21 - 23 | [OBS Repo][obs-repo] |
-| Fedora 24 -25 | `arc-theme` |
+| Fedora | `arc-theme` |
 | Gentoo/Funtoo | `x11-themes/arc-theme` from the [Scriptkitties Overlay][sk-overlay] |
 | openSUSE | [OBS Repo][obs-repo] |
 | Solus | `arc-gtk-theme` |


### PR DESCRIPTION
All currently supported versions of Fedora include Arc theme in the official repository.