### PR TITLE
add arc-plank-darker dock theme

### DIFF
--- a/extra/Arc-Plank-Darker/dock.theme
+++ b/extra/Arc-Plank-Darker/dock.theme
@@ -1,0 +1,61 @@
+[PlankTheme]
+#The roundness of the top corners.
+TopRoundness=1
+#The roundness of the bottom corners.
+BottomRoundness=0
+#The thickness (in pixels) of lines drawn.
+LineWidth=1
+#The color (RGBA) of the outer stroke.
+OuterStrokeColor=53;;57;;69;;245
+#The starting color (RGBA) of the fill gradient.
+FillStartColor=53;;57;;69;;245
+#The ending color (RGBA) of the fill gradient.
+FillEndColor=53;;57;;69;;245
+#The color (RGBA) of the inner stroke.
+InnerStrokeColor=53;;57;;69;;245
+
+[PlankDockTheme]
+#The padding on the left/right dock edges, in tenths of a percent of IconSize.
+HorizPadding=1
+#The padding on the top dock edge, in tenths of a percent of IconSize.
+TopPadding=1
+#The padding on the bottom dock edge, in tenths of a percent of IconSize.
+BottomPadding=1
+#The padding between items on the dock, in tenths of a percent of IconSize.
+ItemPadding=2
+#The size of item indicators, in tenths of a percent of IconSize.
+IndicatorSize=3
+#The size of the icon-shadow behind every item, in tenths of a percent of IconSize.
+IconShadowSize=0
+#The height (in percent of IconSize) to bounce an icon when the application sets urgent.
+UrgentBounceHeight=1.6666666666666667
+#The height (in percent of IconSize) to bounce an icon when launching an application.
+LaunchBounceHeight=0.625
+#The opacity value (0 to 1) to fade the dock to when hiding it.
+FadeOpacity=1
+#The amount of time (in ms) for click animations.
+ClickTime=300
+#The amount of time (in ms) to bounce an urgent icon.
+UrgentBounceTime=600
+#The amount of time (in ms) to bounce an icon when launching an application.
+LaunchBounceTime=600
+#The amount of time (in ms) for active window indicator animations.
+ActiveTime=300
+#The amount of time (in ms) to slide icons into/out of the dock.
+SlideTime=300
+#The time (in ms) to fade the dock in/out on a hide (if FadeOpacity is < 1).
+FadeTime=250
+#The time (in ms) to slide the dock in/out on a hide (if FadeOpacity is 1).
+HideTime=150
+#The size of the urgent glow (shown when dock is hidden), in tenths of a percent of IconSize.
+GlowSize=30
+#The total time (in ms) to show the hidden-dock urgent glow.
+GlowTime=10000
+#The time (in ms) of each pulse of the hidden-dock urgent glow.
+GlowPulseTime=2000
+#The hue-shift (-180 to 180) of the urgent indicator color.
+UrgentHueShift=150
+#The time (in ms) to move an item to its new position or its addition/removal to/from the dock.
+ItemMoveTime=450
+#Whether background and icons will unhide/hide with different speeds. The top-border of both will leave/hit the screen-edge at the same time.
+CascadeHide=true


### PR DESCRIPTION
There are some changes of Arc-Plank theme that might be named Arc-Darker: removed outer stroke, reduced transparency.

![image](https://user-images.githubusercontent.com/24476604/34599402-289d9e12-f203-11e7-8f1a-3221061d0236.png)
![image](https://user-images.githubusercontent.com/24476604/34599639-8058ecfa-f204-11e7-9fb8-cbfce48e037f.png)
